### PR TITLE
set tls12 before downloading, otherwise download failed with:

### DIFF
--- a/src/install_host_app.bat
+++ b/src/install_host_app.bat
@@ -80,8 +80,8 @@ IF "%USE_LOCAL_FILES%"=="true" (
     COPY /Y "%~dp0%HOST_MANIFEST%" "%HOST_MANIFEST_FULL%"
     COPY /Y "%~dp0%HOST_SCRIPT%" "%HOST_SCRIPT_FULL%"
 ) ELSE (
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('%HOST_URL%', '%HOST_SCRIPT_FULL%')"
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('%MANIFEST_URL%', '%HOST_MANIFEST_FULL%')"
+    powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; (New-Object Net.WebClient).DownloadFile('%HOST_URL%', '%HOST_SCRIPT_FULL%')"
+    powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; (New-Object Net.WebClient).DownloadFile('%MANIFEST_URL%', '%HOST_MANIFEST_FULL%')"
 )
 
 powershell -Command "(Get-Content '%HOST_MANIFEST_FULL%') -replace 'PLACEHOLDER', '%HOST_BATCH_FULL:\=/%' | Set-Content '%HOST_MANIFEST_FULL%'"


### PR DESCRIPTION
```
Ausnahme beim Aufrufen von "DownloadFile" mit 2 Argument(en):  "Die Anfrage wurde abgebrochen: Es konnte kein
geschützter SSL/TLS-Kanal erstellt werden.."
In Zeile:1 Zeichen:1
+ (New-Object Net.WebClient).DownloadFile('https://github.com/passff/pa ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException
```

Where the German error message translates to:
 ```
Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: Could not create SSL/TLS secure channel."
 ```

Many thanks for the great passff plugin! :)