### PR TITLE
Prevent globbing of file paths

### DIFF
--- a/src/install_host_app.sh
+++ b/src/install_host_app.sh
@@ -114,10 +114,10 @@ echo "Installing $BROWSER_NAME host config"
 # Create config dir if not existing
 mkdir -p "$TARGET_DIR"
 
-PATH_ESC="$(echo $PATH | sed -e 's/@/\\@/g')"
-PASS_PATH_ESC="$(echo $PASS_PATH | sed -e 's/@/\\@/g')"
-HOST_FILE_PATH_ESC="$(echo $HOST_FILE_PATH | sed -e 's/@/\\@/g')"
-PYTHON3_PATH_ESC="$(echo $PYTHON3_PATH | sed -e 's/@/\\@/g')"
+PATH_ESC="$(echo "$PATH" | sed -e 's/@/\\@/g')"
+PASS_PATH_ESC="$(echo "$PASS_PATH" | sed -e 's/@/\\@/g')"
+HOST_FILE_PATH_ESC="$(echo "$HOST_FILE_PATH" | sed -e 's/@/\\@/g')"
+PYTHON3_PATH_ESC="$(echo "$PYTHON3_PATH" | sed -e 's/@/\\@/g')"
 
 # Replace path to python3 executable \
 # Replace path to pass (only in a line starting with "COMMAND =") \


### PR DESCRIPTION
[Shellcheck](https://www.shellcheck.net/), a linter for shell scripts, has found some minor issues, called [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086):

```
In src/install_host_app.sh line 117:
PATH_ESC="$(echo $PATH | sed -e 's/@/\\@/g')"
                 ^-- SC2086: Double quote to prevent globbing and word splitting.


In src/install_host_app.sh line 118:
PASS_PATH_ESC="$(echo $PASS_PATH | sed -e 's/@/\\@/g')"
                      ^-- SC2086: Double quote to prevent globbing and word splitting.


In src/install_host_app.sh line 119:
HOST_FILE_PATH_ESC="$(echo $HOST_FILE_PATH | sed -e 's/@/\\@/g')"
                           ^-- SC2086: Double quote to prevent globbing and word splitting.


In src/install_host_app.sh line 120:
PYTHON3_PATH_ESC="$(echo $PYTHON3_PATH | sed -e 's/@/\\@/g')"
                         ^-- SC2086: Double quote to prevent globbing and word splitting.
```

Let's test that:

```
$ nasty_path="/usr/local/* /passff.py" # who does that???
$ echo $nasty_path | sed -e 's/@/\\@/g'
/usr/local/bin /usr/local/etc /usr/local/games /usr/local/include /usr/local/lib /usr/local/libexec /usr/local/man /usr/local/sbin /usr/local/share /usr/local/src /passff.py
```
!!! :100: 

Strangely enough, it does not work on my zsh. 