### PR TITLE
Host app support for OTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ In the preferences of PassFF, you can enable the status bar and debug logs in th
 * The typical output for an empty store is:
   * `{"stderr": "", "version": "1.0.1", "exitCode": 0, "stdout": "Password Store\n"}`
 
+#### Testing OTP support
+```console
+$ echo -e "\x19\x00\x00\x00[\"otp\",\"/www/github.com\"]" | /path/to/passff.py | tail -c +4; echo
+{"exitCode": 0, "stderr": "", "stdout": "123456\n", "version": "1.0.1"}
+```
+
 ### Preferences
 If you use a customized `pass` installation: environment variables, customized repository path or extensions, you may have to customize the *preferences section* in `passff.py`.
 

--- a/src/passff.py
+++ b/src/passff.py
@@ -62,6 +62,11 @@ if __name__ == "__main__":
         pos_args = [receivedMessage[1], receivedMessage[2]]
         if "-n" in receivedMessage[3:]:
             opt_args.append("-n")
+    elif receivedMessage[0] == "otp" and len(receivedMessage) == 2:
+        opt_args = ["otp"]
+        key = receivedMessage[1]
+        key = "/" + (key[1:] if key[0] == "/" else key)
+        pos_args = [key]
     else:
         opt_args = ["show"]
         key = receivedMessage[0]


### PR DESCRIPTION
This provides [pass-otp](https://github.com/tadfisher/pass-otp) host app support for [#200](https://github.com/passff/passff/issues/200). The browser extension will also need to be updated.

```console
$ echo -e "\x19\x00\x00\x00[\"otp\",\"/www/github.com\"]" | /path/to/passff.py | tail -c +4; echo
{"exitCode": 0, "stderr": "", "stdout": "123456\n", "version": "1.0.1"}
```
