### PR TITLE
Update minimum python version to 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This piece of software wraps around the **[zx2c4 pass](http://www.zx2c4.com/proj
 ### Dependencies
 
 #### For the host application
-* [`python3`](https://docs.python.org/3.5/) (>= 3.5)
+* [`python3`](https://docs.python.org/3.6/) (>= 3.6)
 * [`pass`](https://www.passwordstore.org/)
 
 #### For the install script (except Windows)


### PR DESCRIPTION
Fixes #39.

Since [PEP 498](https://www.python.org/dev/peps/pep-0498/) formatting strings are used, the minimum python version should now be 3.6.

Note that Python 3.6 is not yet available on Debian stable.