### PR TITLE
Use argparse for argument parsing in passff.py

### DIFF
--- a/src/passff.py
+++ b/src/passff.py
@@ -4,31 +4,55 @@
     that wraps around the zx2c4 pass script.
 """
 
+import argparse
 import json
 import os
 import struct
 import subprocess
 import sys
 
+from typing import Any, Dict, List
+
 VERSION = "_VERSIONHOLDER_"
 
 ###############################################################################
 ######################## Begin preferences section ############################
 ###############################################################################
-COMMAND = "pass"
-COMMAND_ARGS = []
-COMMAND_ENV = {
-    "TREE_CHARSET": "ISO-8859-1",
-    "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
-}
-CHARSET = "UTF-8"
+
+# The command to use when invoking pass.
+PASS_COMMAND = "pass"
+
+# Any additional arguments to unconditionally use when invoking PASS_COMMAND.
+PASS_COMMAND_ARGS = []
+
+# Any additional environment variables to set when invoking PASS_COMMAND.
+DEFAULT_COMMAND_ENV = {}
+
+# The default stdin/stdout charset (if none can be auto-detected).
+DEFAULT_CHARSET = "UTF-8"
 
 ###############################################################################
 ######################### End preferences section #############################
 ###############################################################################
 
 
-def getMessage():
+def detect_charset() -> str:
+    """Attempt to automatically detect the charset, or return DEFAULT_CHARSET if
+    none could be auto-detected.
+    """
+    # If the user has LANG or LC_ALL set to a string like "en_us.UTF8", try to
+    # use that as the default charset.
+    for langvar in ['LANG', 'LC_ALL']:
+        envval = os.environ.get('langvar', '')
+        if '.' in envval:
+            return envval.split('.', 1)[1]
+
+    # If no charset could be auto-detected using the previous method (e.g.
+    # LANG=C, or LANG/LC_ALL were not set) then use DEFAULT_CHARSET.
+    return DEFAULT_CHARSET
+
+
+def getMessage() -> Any:
     """ Read a message from stdin and decode it. """
     rawLength = sys.stdin.buffer.read(4)
     if len(rawLength) == 0:
@@ -38,21 +62,25 @@ def getMessage():
     return json.loads(message)
 
 
-def encodeMessage(messageContent):
+def encodeMessage(messageContent) -> Dict[str, Any]:
     """ Encode a message for transmission, given its content. """
     encodedContent = json.dumps(messageContent)
     encodedLength = struct.pack('@I', len(encodedContent))
     return {'length': encodedLength, 'content': encodedContent}
 
 
-def sendMessage(encodedMessage):
+def sendMessage(encodedMessage) -> None:
     """ Send an encoded message to stdout. """
     sys.stdout.buffer.write(encodedMessage['length'])
     sys.stdout.write(encodedMessage['content'])
     sys.stdout.flush()
 
 
-if __name__ == "__main__":
+def invoke_pass(pass_command: str,
+                command_args: List[str],
+                command_env: Dict[str, str],
+                charset: str) -> None:
+    """Invoke the pass command and communicate with it using stdin/stdout."""
     # Read message from standard input
     receivedMessage = getMessage()
     opt_args = []
@@ -84,19 +112,19 @@ if __name__ == "__main__":
         key = receivedMessage[0]
         key = "/" + (key[1:] if key[0] == "/" else key)
         pos_args = [key]
-    opt_args += COMMAND_ARGS
+    opt_args += command_args
 
     # Set up (modified) command environment
     env = dict(os.environ)
     if "HOME" not in env:
         env["HOME"] = os.path.expanduser('~')
-    for key, val in COMMAND_ENV.items():
+    for key, val in command_env.items():
         env[key] = val
 
     # Set up subprocess params
-    cmd = [COMMAND] + opt_args + ['--'] + pos_args
+    cmd = [pass_command] + opt_args + ['--'] + pos_args
     proc_params = {
-        'input': bytes(std_input, CHARSET) if std_input else None,
+        'input': bytes(std_input, charset) if std_input else None,
         'stdout': subprocess.PIPE,
         'stderr': subprocess.PIPE,
         'env': env
@@ -109,7 +137,49 @@ if __name__ == "__main__":
     sendMessage(
         encodeMessage({
             "exitCode": proc.returncode,
-            "stdout": proc.stdout.decode(CHARSET),
-            "stderr": proc.stderr.decode(CHARSET),
+            "stdout": proc.stdout.decode(charset),
+            "stderr": proc.stderr.decode(charset),
             "version": VERSION
         }))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-V', '--version', action='store_true',
+                        help='Print passff-host version')
+    parser.add_argument('-c', '--pass-command', default=PASS_COMMAND,
+                        help='Executable to use as the "pass" command')
+    parser.add_argument('-E', '--env', action='append',
+                        help='Additional env vars to use in pass process '
+                        'environment, supplied in format KEY=VAL')
+    parser.add_argument('--charset', default=detect_charset(),
+                        help='Charset to use for stdin/stdout communication')
+    args = parser.parse_args()
+
+    # If the -V or --version flag was used, just print the passff-host version
+    # and exit.
+    if args.version:
+        print(VERSION)
+        return
+
+    # Unconditionally add PASS_COMMAND_ARGS to the pass command, and also add
+    # any additional positional arguments from the argument parser.
+    command_args = PASS_COMMAND_ARGS + args.args
+
+    # Update DEFAULT_COMMAND_ENV with any env vars supplied by the -E or --env
+    # flags. These should be in the format of key=val, for example:
+    #
+    #   passff.py -E foo=val
+    #
+    # Could be used to force foo=val in the pass environment.
+    command_env = DEFAULT_COMMAND_ENV.copy()
+    for env_keyval in args.env:
+        key, val = env_keyval.split('=', 1)
+        command_env[key] = val
+
+    # Invoke the pass command
+    invoke_pass(args.pass_command, command_args, command_env, args.charset)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The original motivation for this change was just to add a `-V` or `--version` command to print the passff-host version. The reason I wanted such a flag is that I just Ansible to manage a bunch of things on my hosts, and I wanted to automatically ensure that the installed version of passff-host matches the version I have set in my Ansible config. Hence the need for a `-V` flag: that way I can compare the installed passff-host command to the expected version when Ansible runs, and update passff-host if necessary.

One more note: the `argparse` module has been built into Python since the Python 2.x days, so this doesn't add any additional dependencies to passff-host.

While I was making this change, I took the opportunity to clean a few other things up:
 * Use Python3 type annotations; this doesn't really add a lot, but since the code depends on Python3 anyway why not.
 * Keep the global preferences variables, and make them keep working as before (in the sense that a user can just modify these to customize `passff.py`), but make the use of globals in the code a little less explcit by passing them to functions in most cases. This will make it easier to write test cases for passff.py, although I have not done that yet.
 * Remove `TREE_CHARSET` and `PATH` from the default `COMMAND_ENV`. My reasoning is:
   * `TREE_CHARSET` is only used by the `tree(1)` command AFAICT, and I don't see why that would have ever been required in the first place.
    * `PATH` should always already be set, it's set by the window manager/login system on every operating system I know of. If the user has decided to customize `PATH` in some way, `passff-host` shouldn't be overriding this. For example, let's say I install commands like `pass` to `~/.local/bin` and already have that set in my `PATH`, it would be really confusing and difficult for me to debug if `passff.py` is arbitrarily deciding to override that.
 * In most cases `LANG` or `LC_ALL` are set on modern operating systems such that the appropriate charset can be detected from those variables. If not, we just use `DEFAULT_CHARSET` as before.

Most of these argument flags will never be used by users because the actual browser extension will be invoking `passff.py` without any arguments, and therefore in general to get customized behavior users will still have to modify the global variables in the preferences section. However, it's easy to imagine changing the browser extension to invoke `passff.py` using the new arguments feature, which would be nice beacuse then these properties could be added to the browser extension configuration UI. Also, the fact that it's now possible to alter these settings using command line flags makes it easier for developers of passff-host to test the behavior of the program manually without editing the code to passff.py