### PR TITLE
fix #25: UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe1

### DIFF
--- a/src/passff.py
+++ b/src/passff.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     sendMessage(
         encodeMessage({
             "exitCode": proc.returncode,
-            "stdout": proc.stdout.decode(CHARSET),
-            "stderr": proc.stderr.decode(CHARSET),
+            "stdout": proc.stdout.decode(CHARSET, 'ignore'),
+            "stderr": proc.stderr.decode(CHARSET, 'ignore'),
             "version": VERSION
         }))


### PR DESCRIPTION
Traceback (most recent call last):
  File "/Users/mytory/Library/Application Support/Mozilla/NativeMessagingHosts/passff.py", line 112, in <module>
    "stdout": proc.stdout.decode(CHARSET),
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe1 in position 119: invalid continuation byte