### PR TITLE
Add support for gopass

### DIFF
--- a/src/passff.py
+++ b/src/passff.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
 
     if len(receivedMessage) == 0:
         opt_args = ["show"]
+        pos_args = ["/"]
     elif receivedMessage[0] == "insert":
         opt_args = ["insert", "-m"]
         pos_args = [receivedMessage[1]]


### PR DESCRIPTION
[gopass ](https://github.com/gopasspw/gopass) does not support using the show command without a path. Adding in the root path as an arg when asking for the full password list allows gopass to work without breaking the original pass script.

Advantage of supporting gopass is that it simplifies windows setup since there is a windows version of gopass.