### PR TITLE
README.md: add a few more troubleshooting tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ In the preferences of PassFF, you can enable the status bar and debug logs in th
 * The typical output for an empty store is:
   * `{"stderr": "", "version": "1.0.1", "exitCode": 0, "stdout": "Password Store\n"}`
 
+#### Check the error code on failure
+```console
+$ strace -f --trace=execve --string-limit=256 firefox 2>&1 |grep passff
+[pid 73124] execve("/home/<USER>/.mozilla/native-messaging-hosts/passff.py", ["/home/<USER>/.mozilla/native-messaging-hosts/passff.py", "/home/<USER>/.mozilla/native-messaging-hosts/passff.json", "passff@invicem.pro"], 0x7fce6a83e500 /* 77 vars */) = -1 EACCES (Permission denied)
+```
+
+#### Check the security module configuration
+If your browser is confined by a security module such as AppArmor, then its policies might deny the execution of the host application, resulting in syslog entries like this:
+```console
+$ grep passff /var/log/syslog
+Apr 22 19:55:24 <HOST> kernel: [70746.170024] audit: type=1400 audit(1650650124.793:2258): apparmor="DENIED" operation="exec" profile="firefox" name="/home/<USER>/.mozilla/native-messaging-hosts/passff.py" pid=73124 comm=444F4D20576F726B6572 requested_mask="x" denied_mask="x" fsuid=1000 ouid=1000
+```
+
 #### Testing OTP support
 ```console
 $ echo -e "\x19\x00\x00\x00[\"otp\",\"/www/github.com\"]" | /path/to/passff.py | tail -c +4; echo


### PR DESCRIPTION
I've run into some difficulties setting up the passff host
application, and the existing troubleshooting tips weren't really
useful, because they don't cover my issues.

Add two more tips that would have helped me diagnose the situation:

  - Recommend a `strace`-based command to check the `errno` of a
    potentially failed `execve(".../passff.py", ...)` call, as it
    might contain a useful clue about why the host application isn't
    even executed.  Use a higher-than-default `--string-limit` in the
    example to prevent truncating `execve()`'s reasonably-sized path
    arguments.

    AFAIK this error code is not available elsewhere: the passff popup
    in the browser only shows `execve()`'s return value (e.g.: "ls ->
    (-1) PassFF failed to execute the host app"), while the browser
    console only shows a fairly useless error message ("Attempt to
    postMessage on disconnected port").

  - Recommend checking the security module configurations and related
    syslog entries, because their policies might deny the execution of
    the host application, resulting in `execve()` failing with
    `EACCES`.

Especially this second tip would have been helpful for me, because
`execve()`'s man page doesn't explicitly list security modules as a
possible cause for `EACCES`, and all listed causes (search permission
on all path components, executable bit, no `noexec` mount) were fine,
so it took a while until I stumbled upon the syslog messages from
AppArmor denying the execution of the passff host application.