### PR TITLE
Expand home directory in PATH

### DIFF
--- a/src/install_host_app.sh
+++ b/src/install_host_app.sh
@@ -106,7 +106,8 @@ fi
 
 PASS_PATH="$(which pass)"
 if [ -x "$PASS_PATH" ]; then
-  echo "Pass executable located at $PASS_PATH"
+  echo -n "Pass executable located at "
+  echo "$PASS_PATH" | sed -e "s@$HOME@~@g"
 else
   echo "Pass executable not found, but Pass is required for PassFF to work!"
   exit 1
@@ -125,8 +126,8 @@ echo "Installing $BROWSER_NAME host config"
 # Create config dir if not existing
 mkdir -p "$TARGET_DIR"
 
-
 PATH_ESC="$(echo "$PATH" | sed -e 's/@/\\@/g')"
+PATH_HOMED="$(echo "$PATH_ESC" | sed -e "s@$HOME@~@g")"
 HOST_FILE_PATH_ESC="$(echo "$HOST_FILE_PATH" | sed -e 's/@/\\@/g')"
 PYTHON3_PATH_ESC="$(echo "$PYTHON3_PATH" | sed -e 's/@/\\@/g')"
 
@@ -134,7 +135,7 @@ PYTHON3_PATH_ESC="$(echo "$PYTHON3_PATH" | sed -e 's/@/\\@/g')"
 # Set the PATH to match this script's \
 HOST_SED=" \
 1 s@.*@#!${PYTHON3_PATH_ESC}@; \
-s@\"PATH\":.*@\"PATH\": \"$PATH_ESC\"@; \
+s@\"PATH\":.*@\"PATH\": \"$PATH_HOMED\"@; \
 "
 # Replace path to host \
 MANIFEST_SED=" \

--- a/src/install_host_app.sh
+++ b/src/install_host_app.sh
@@ -125,17 +125,15 @@ echo "Installing $BROWSER_NAME host config"
 # Create config dir if not existing
 mkdir -p "$TARGET_DIR"
 
+
 PATH_ESC="$(echo "$PATH" | sed -e 's/@/\\@/g')"
-PASS_PATH_ESC="$(echo "$PASS_PATH" | sed -e 's/@/\\@/g')"
 HOST_FILE_PATH_ESC="$(echo "$HOST_FILE_PATH" | sed -e 's/@/\\@/g')"
 PYTHON3_PATH_ESC="$(echo "$PYTHON3_PATH" | sed -e 's/@/\\@/g')"
 
 # Replace path to python3 executable \
-# Replace path to pass (only in a line starting with "COMMAND =") \
 # Set the PATH to match this script's \
 HOST_SED=" \
 1 s@.*@#!${PYTHON3_PATH_ESC}@; \
-/^COMMAND *=/s@\"pass\"@\"$PASS_PATH_ESC\"@; \
 s@\"PATH\":.*@\"PATH\": \"$PATH_ESC\"@; \
 "
 # Replace path to host \

--- a/src/passff.py
+++ b/src/passff.py
@@ -28,6 +28,11 @@ CHARSET = "UTF-8"
 ###############################################################################
 
 
+COMMAND_ENV["PATH"] = ":".join(
+    os.path.expanduser(p) for p in COMMAND_ENV["PATH"].split(":")
+)
+
+
 def getMessage():
     """ Read a message from stdin and decode it. """
     rawLength = sys.stdin.buffer.read(4)


### PR DESCRIPTION
I synchronise configs between machines that have `$HOME` in different places. These patches ensure that no such paths are hard-coded into the `passff.py` script. Note that the manifest is still using an absolute path, but I have not found out how to fix that yet.