### PR TITLE
Fix: silent fail when python3 or pass not found

### DIFF
--- a/src/install_host_app.sh
+++ b/src/install_host_app.sh
@@ -96,16 +96,16 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-PYTHON3_PATH="$(which python3)"
-if [ -x "$PYTHON3_PATH" ]; then
-  echo "Python 3 executable located at $PYTHON3_PATH"
+if which python3 >/dev/null 2>&1; then
+  PYTHON3_PATH="$(which python3)"
+    echo "Python 3 executable located at $PYTHON3_PATH"
 else
   echo "Python 3 executable not found, but Python 3 is required for PassFF to work!"
   exit 1
 fi
 
-PASS_PATH="$(which pass)"
-if [ -x "$PASS_PATH" ]; then
+if which pass >/dev/null 2>&1; then
+  PASS_PATH="$(which pass)"
   echo "Pass executable located at $PASS_PATH"
 else
   echo "Pass executable not found, but Pass is required for PassFF to work!"


### PR DESCRIPTION
Under `set -e`, `"$(which python3)"` counts as error (if `python3` is not found) unless within an if statement's test. If `pass` or `python3` are not installed, the script fails silently _before reaching the error message_. To replicate, try adding a typo, e.g. `PYTHON3_PATH="$(which python3asdfj)".

This fix only assigns PATHs after checking that `which` won't fail. It also makes it unnecessary to run `if [ -x "$PYTHON_PATH" ]`, because `which` only returns 0 when an _executable_ is found.

Tested on bash 5.1.16, but I think `errexit`'s behavior hasn't changed.