### PR TITLE
Add installer support for gopass

### DIFF
--- a/src/install_host_app.sh
+++ b/src/install_host_app.sh
@@ -104,7 +104,7 @@ else
   exit 1
 fi
 
-PASS_PATH="$(which pass)"
+PASS_PATH="$(which pass || which gopass)"
 if [ -x "$PASS_PATH" ]; then
   echo "Pass executable located at $PASS_PATH"
 else


### PR DESCRIPTION
gopass support was [previously added](https://github.com/passff/passff-host/pull/53), but gopass doesn't support using the `show` command to show the directory list anymore. The `ls` command works with both pass and gopass.

The installer can also work if only gopass is installed.