### PR TITLE
Fix running on M1 Mac by adding new OSX homebrew path for M1 to passff.py

### DIFF
--- a/src/passff.py
+++ b/src/passff.py
@@ -19,7 +19,7 @@ COMMAND = "pass"
 COMMAND_ARGS = []
 COMMAND_ENV = {
     "TREE_CHARSET": "ISO-8859-1",
-    "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin",
 }
 CHARSET = "UTF-8"
 


### PR DESCRIPTION
When installing `pass` via homebrew on M1 Macs (the native arm64 silicon port) via homebrew 3.0.0 or newer, the binaries `pass` and `tree` will be installed to `/opt/homebrew/bin`.

Using the default path in `pass.py` the host application is not able to locate `pass` so you get the usual errors about communicating with the host app not working.

Setting the path to the `pass` binary to `/opt/homebrew/bin/pass` (which would be the smaller change) unfortunately does not fix the host app issue fully, as whilst this allows the host app to work and communicate with passff, `tree` is needed by `pass` for actually listing out the password repository, and this is also installed in `/opt/homebrew/bin`.

This single-line change adds the new homebrew path `/opt/homebrew/bin/` to the end of the search path so the binaries will be found on M1 Macs. Putting them at the end of the list was strategic, as putting it at the start of the list would mean unnecessarily checking for this folder on the majority of systems running this extension.

I have tested this on version 1.14 of the extension with `pass` 1.7.4 installed via homebrew and it is working as expected.