### PR TITLE
Use passpy module vs creating sub-process to pass or gopass

### DIFF
--- a/src/passff.py
+++ b/src/passff.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 #!/usr/bin/env python3
 """
     Host application of the browser extension PassFF
@@ -7,26 +9,37 @@
 import json
 import os
 import struct
-import subprocess
 import sys
+import passpy
+import re
 
-VERSION = "_VERSIONHOLDER_"
+VERSION = "2.0.0"
 
 ###############################################################################
 ######################## Begin preferences section ############################
 ###############################################################################
-COMMAND = "pass"
-COMMAND_ARGS = []
-COMMAND_ENV = {
-    "TREE_CHARSET": "ISO-8859-1",
-    "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
-}
-CHARSET = "UTF-8"
-
+GPG_BIN = "C:\\Program Files (x86)\\GnuPG\\bin\\gpg.exe"
+GIT_BIN = None
+STORE_DIR = "C:\\Users\\username\\password-store"
+USE_AGENT = False
 ###############################################################################
 ######################### End preferences section #############################
 ###############################################################################
+# Message constants
+MSG_STORE_NOT_INITIALISED_ERROR = ('You need to call {0} init first.'
+                                   .format(__name__))
+MSG_PERMISSION_ERROR = 'Nah-ah!'
+MSG_FILE_NOT_FOUND = 'Error: {0} is not in the password store.'
+MSG_RECURSIVE_COPY_MOVE_ERROR = 'Error: Can\'t {0} a directory into itself.'
+MSG_NOT_IMPLEMENTED = 'Error: {0} is not implemented.'
 
+# Tree Constants
+SPACES = '    '
+BRIDGE = '│   '
+BRANCH = '├── '
+ENDING = '└── '
+    
+store = passpy.Store(gpg_bin = GPG_BIN, git_bin = GIT_BIN, store_dir = STORE_DIR, use_agent = USE_AGENT, interactive = False, verbose = False)
 
 def getMessage():
     """ Read a message from stdin and decode it. """
@@ -50,67 +63,168 @@ def sendMessage(encodedMessage):
     sys.stdout.buffer.write(encodedMessage['length'])
     sys.stdout.write(encodedMessage['content'])
     sys.stdout.flush()
+    
+def _gen_tree(lines):
+    """Create hierarchical file tree from key names.
 
+    :param list lines: A list of key names from the password store.
+
+    :rtype: dict
+    :returns: A nested dictionary with directories and key names as
+        it's keys.
+
+    """
+    tree = {}
+    for line in lines:
+        ctree = tree
+        for segment in line.split(os.sep):
+            if segment not in ctree:
+                ctree[segment] = {}
+            ctree = ctree[segment]
+
+    return tree
+
+def _print_tree(tree, seperators=None):
+    """Print a depth indented listing.
+
+    The algorithm for printing the tree has been taken from `doctree`_
+    written by Mihai Ciumeicaă and licensed under the MIT licence.  The
+    code has been adapted to fit our needs.
+
+    .. _doctree: https://github.com/cmihai/docktree
+
+    :param dict tree: A dictionary created by
+        :func:`passpy.__main__._gen_tree`.
+
+    :param list seperators: (optional) The seperators to print before
+       the leaf name.  Leave empty when calling this function.
+
+    """
+    if seperators is None:
+        seperators = []
+
+    tree_out = ''
+    
+    length = len(tree)
+    for i, entry in enumerate(sorted(tree, key=str.lower)):
+        for seperator in seperators:
+            if seperator:
+                tree_out += BRIDGE
+            else:
+                tree_out += SPACES
+        if i < length - 1:
+            tree_out += BRANCH
+            tree_out += entry + "\n"
+            tree_out += _print_tree(tree[entry], seperators + [1])
+        else:
+            tree_out += ENDING
+            tree_out += entry + "\n"
+            tree_out += _print_tree(tree[entry], seperators + [0])
+
+    return tree_out
 
 if __name__ == "__main__":
     # Read message from standard input
     receivedMessage = getMessage()
-    opt_args = []
-    pos_args = []
-    std_input = None
+        
+    outCode = 0
+    outMessage = None
+    outError = None
 
     if len(receivedMessage) == 0:
-        opt_args = ["show"]
-        pos_args = ["/"]
+        try:
+            keys = list(store.iter_dir('.'))
+        except StoreNotInitialisedError:
+            outError = MSG_STORE_NOT_INITIALISED_ERROR
+            outCode = 1
+        except FileNotFoundError:
+            outError = MSG_FILE_NOT_FOUND.format(subfolder)
+            outCode = 1
+            
+        tree = _gen_tree(keys)
+        outMessage = _print_tree(tree)
     elif receivedMessage[0] == "insert":
-        opt_args = ["insert", "-m"]
-        pos_args = [receivedMessage[1]]
-        std_input = receivedMessage[2]
+        force = receivedMessage[1]
+        data = receivedMessage[2]
+        store.set_key(pass_name, data, force=force)
     elif receivedMessage[0] == "generate":
-        opt_args = ["generate"]
-        pos_args = [receivedMessage[1], receivedMessage[2]]
+        pass_name = receivedMessage[1]
+        pass_length = receivedMessage[2]
+        symbols = True
         if "-n" in receivedMessage[3:]:
-            opt_args.append("-n")
+            symbols = False
+        force = False
+        in_place = False
+
+        try:
+            password = store.gen_key(pass_name, pass_length, symbols, force, in_place)
+        except StoreNotInitialisedError:
+            outError = MSG_STORE_NOT_INITIALISED_ERROR
+            outCode = 1
+        except PermissionError:
+            outError = MSG_PERMISSION_ERROR
+            outCode = 1
+        except FileNotFoundError:
+            outError = MSG_FILE_NOT_FOUND.format(pass_name)
+            outCode = 1
+
+        if password is None:
+            outCode = 1
+
+        outMessage = 'The generated password for {0} is:'.format(pass_name) + "\n" + password
     elif receivedMessage[0] == "grepMetaUrls" and len(receivedMessage) == 2:
-        opt_args = ["grep", "-iE"]
         url_field_names = receivedMessage[1]
-        pos_args = ["^({}):".format('|'.join(url_field_names))]
+        searchTerm = "^({}):".format('|'.join(url_field_names))
+
+        try:
+            results = store.search(searchTerm)
+        except passpy.StoreNotInitialisedError:
+            outError = MSG_STORE_NOT_INITIALISED_ERROR
+            outCode = 1
+
+        outMessage = ''
+
+        for key in results:
+            outMessage += key.replace("\\", '/') + ':' + "\n"
+            
+            for line, match in results[key]:
+                start = match.start()
+                end = match.end()
+                
+                line[:start]
+                outMessage += line[:start]
+                if re.match(r"^\s*$", line[:start]) != None:
+                    outMessage + "\n"
+                outMessage += line[start:end]
+                outMessage += line[end:] + "\n"
     elif receivedMessage[0] == "otp" and len(receivedMessage) == 2:
-        opt_args = ["otp"]
-        key = receivedMessage[1]
-        key = "/" + (key[1:] if key[0] == "/" else key)
-        pos_args = [key]
+        outCode = 1
+        outError = MSG_NOT_IMPLEMENTED.format('OTP')
     else:
-        opt_args = ["show"]
         key = receivedMessage[0]
-        key = "/" + (key[1:] if key[0] == "/" else key)
-        pos_args = [key]
-    opt_args += COMMAND_ARGS
+        if key[0] == "/":
+            del key[0] 
+        
+        try:
+            data = store.get_key(pass_name)
+        except StoreNotInitialisedError:
+            outError = MSG_STORE_NOT_INITIALISED_ERROR
+            outCode = 1
+        except FileNotFoundError:
+            outError = MSG_FILE_NOT_FOUND.format(pass_name)
+            outcode = 1
+        except PermissionError:
+            outError = MSG_PERMISSION_ERROR
+            outCode = 1
 
-    # Set up (modified) command environment
-    env = dict(os.environ)
-    if "HOME" not in env:
-        env["HOME"] = os.path.expanduser('~')
-    for key, val in COMMAND_ENV.items():
-        env[key] = val
+        outMessage = data
 
-    # Set up subprocess params
-    cmd = [COMMAND] + opt_args + ['--'] + pos_args
-    proc_params = {
-        'input': bytes(std_input, CHARSET) if std_input else None,
-        'stdout': subprocess.PIPE,
-        'stderr': subprocess.PIPE,
-        'env': env
-    }
-
-    # Run and communicate with pass script
-    proc = subprocess.run(cmd, **proc_params)
-
-    # Send response
+    # Send the message
     sendMessage(
         encodeMessage({
-            "exitCode": proc.returncode,
-            "stdout": proc.stdout.decode(CHARSET),
-            "stderr": proc.stderr.decode(CHARSET),
+            "exitCode": outCode,
+            "stdout": outMessage,
+            "stderr": outError,
             "version": VERSION
-        }))
+        })
+    )


### PR DESCRIPTION
Specify encoding as UTF-8
Specify paths to gpg, git, and password store
Replicate some functions of pass/gopass directly (via passpy)

This change as a bit rough around the edges as some paths, etc. are hard-coded into the script, but hopefully still useful even if not taken in its entirety.

This change was born out of:

1. No native pass CLI not existing for Windows (AFAIK)
2. URL caching not working in Windows due to path separator difference from *nix (\ vs. /)
3. Gopass and/or passff requiring changes to deal with path separator differences

Changing to rely on passpy and keeping the whole thing Pythonic seemed like the cleanest solution.