### PR TITLE
Allow error code extraction from GPG by including debug output

### DIFF
--- a/src/passff.py
+++ b/src/passff.py
@@ -97,13 +97,11 @@ def getGpgCodesFromStderr(stderr):
                 gpg_error_code = 17
 
     # filter out debug and status outputs
-    stderr_filtered = '\n'.join([
-        msg for msg in messages if not (
-            msg.startswith("gpg: DBG:")
-            or msg.startswith("[GNUPG:]")
-        )
-    ])
-    
+    stderr_filtered = '\n'.join(
+        msg for msg in messages
+        if not msg.startswith(("gpg: DBG:", "[GNUPG:]"))
+    )
+
     return stderr_filtered, gpg_error_code
 
 

--- a/src/passff.py
+++ b/src/passff.py
@@ -63,7 +63,7 @@ def setFlags(env, flags):
         opts = '--%s%s %s' % (
             flag,
             value,
-            re.sub(r'--%s(?:=|\s+)\S*' % flag, '', opts)
+            re.sub(r'--%s(?:(?:=|\s+)\S*)?' % flag, '', opts)
         )
     env['PASSWORD_STORE_GPG_OPTS'] = opts.strip()
 

--- a/src/passff.py
+++ b/src/passff.py
@@ -88,10 +88,17 @@ def getGpgCodesFromStderr(stderr):
             elif 'NO_SECKEY' in line:
                 gpg_error_code = 17
         elif len(preserve) > 0 and line.startswith('  '):
-            # gpg indented line continuation
-            preserve[-1] += '\n' + line
-        elif not line.startswith("gpg: "):
-            preserve.append(line)
+            # append gpg indented line continuation to previous entry
+            preserve[-1] += f"\n{line}"
+        preserve.append(line)
+    # filter out debug and status outputs
+    # (including indented line continuations)
+    preserve = [
+        line for line in preserve if not (
+            line.startswith("gpg: DBG:")
+            or line.startswith("[GNUPG:]")
+        )
+    ]
     return '\n'.join(preserve), gpg_error_code
 
 

--- a/src/passff.py
+++ b/src/passff.py
@@ -80,17 +80,17 @@ def getGpgCodesFromStderr(stderr):
         if line.startswith('gpg: DBG:'):
             m = re.search(r'chan_\d+ (?:<-|->) ERR (\d+)', line)
             if m is not None:
-                error_code = int(m.group(1)) & 0xFFFF
+                gpg_error_code = int(m.group(1)) & 0xFFFF
         elif line.startswith("[GNUPG:]"):
             m = re.search(r'ERROR pkdecrypt_failed (\d+)', line)
             if m is not None:
-                error_code = int(m.group(1)) & 0xFFFF
+                gpg_error_code = int(m.group(1)) & 0xFFFF
             elif 'NO_SECKEY' in line:
-                error_code = 17
+                gpg_error_code = 17
         elif len(preserve) > 0 and line.startswith('  '):
             # gpg indented line continuation
             preserve[-1] += '\n' + line
-        else:
+        elif not line.startswith("gpg: "):
             preserve.append(line)
     return '\n'.join(preserve), gpg_error_code
 

--- a/src/passff.py
+++ b/src/passff.py
@@ -58,13 +58,17 @@ def setPassGpgOpts(env, opts_dict):
     """ Add arguments to PASSWORD_STORE_GPG_OPTS. """
     opts = env.get('PASSWORD_STORE_GPG_OPTS', '')
     for opt, value in opts_dict.items():
-        re_opt = f"--{opt}"
+        re_opt = new_opt = opt
         if value is not None:
-            value = f"={shlex.quote(value)}"
-            re_opt = rf"--{opt}(?:=|\s+)\S*"
+            re_opt = rf"{opt}(?:=|\s+)\S*"
+            new_opt = (
+                f"{opt}={shlex.quote(value)}"
+                if opt.startswith("--") else
+                f"{opt} {shlex.quote(value)}"
+            )
         # If the user's environment sets this opt, remove it.
         opts = re.sub(re_opt, '', opts)
-        opts = f"--{opt}{value} {opts}"
+        opts = f"{new_opt} {opts}"
     env['PASSWORD_STORE_GPG_OPTS'] = opts.strip()
 
 
@@ -138,7 +142,7 @@ if __name__ == "__main__":
         env["HOME"] = os.path.expanduser('~')
     for key, val in COMMAND_ENV.items():
         env[key] = val
-    setPassGpgOpts(env, {'status-fd': '2', 'debug': 'ipc'})
+    setPassGpgOpts(env, {'--status-fd': '2', '--debug': 'ipc'})
 
     # Set up subprocess params
     cmd = [COMMAND] + opt_args + ['--'] + pos_args


### PR DESCRIPTION
This PR is a backend change in support of future work on passff/passff#544.

It enables `--debug=ipc` to override the `--quiet` on the command line that `pass` sends to `gpg`, and `--status-fd=2` to enable non-localized messages sent to stderr. The stderr output is then parsed looking for error codes and filtering out the excessive detail that causes before passing it off to the UI. It adds an `"errorCode":` key to the json output that's sent to firefox, with the value being an integer code from [`err-codes.h.in`](https://github.com/gpg/libgpg-error/blob/master/src/err-codes.h.in#L32) if detected, or 0. "No code detected" and "No error" use the same code intentionally. The `"exitCode":` key has been left in place for compatibility (with mismatched addon+host versions) and to disambiguate those cases.

Because the details about how these errors are returned in the GPG output vary from version to version, I've created a test harness to test every supportable gpg version in an assortment of docker containers. This test code is... very ad-hoc. I've committed it to [my fork if you want to peruse the code or reproduce my results](https://github.com/drmoose/passff-host/blob/here-there-be-dragons/test.py) but haven't included it in this PR because re-running it in the future strikes me as being of questionable utility without something like Github Actions.

The output of my testing is the table below, which has columns for each of the conditions I've endeavored to detect. Columns >= 4 represent test runs where I expect a particular error code. Icons are described in the legend below.


| distro           | gpg version | libgcrypt | Found          | Cancel (99)          | Bad Pin (11)         | No Pinentry (85)     | No Secret (17)                 |
|------------------|-------------|-----------|----------------|----------------------|----------------------|----------------------|--------------------------------|
| `fedora:38`      | 2.4.0       | 1.10.2    | :es: :jp: :us: | :es: :jp: :us:       | :es: :jp: :us:       | :es: :jp: :us:       | :es: :jp: :us:                 |
| `fedora:37`      | 2.3.8       | 1.10.1    | :es: :jp: :us: | :es: :jp: :us:       | :es: :jp: :us:       | :es: :jp: :us:       | :es: :jp: :us:                 |
| `rockylinux:9`   | 2.3.3       | 1.10.0    | :es: :jp: :us: | :es: :jp: :us:       | :es: :jp: :us:       | :es: :jp: :us:       | :es: :jp: :us:                 |
| `rockylinux:8`   | 2.2.20      | 1.8.5     | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us:           |
| `centos:7`       | 2.0.22      | 1.5.3     | :es: :jp: :us: |                      |                      |                      |                                |
| `ubuntu`         | 2.2.27      | 1.9.4     | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us:           |
| `ubuntu:rolling` | 2.2.40      | 1.10.1    | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: :warning: |
| `ubuntu:jammy`   | 2.2.27      | 1.9.4     | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us:           |
| `ubuntu:focal`   | 2.2.19      | 1.8.5     | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us:           |
| `ubuntu:bionic`  | 2.2.4       | 1.8.1     | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us:           |
| `debian:sid`     | 2.2.40      | 1.10.2    | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: :warning: |
| `debian:12`      | 2.2.40      | 1.10.1    | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: :warning: |
| `debian:11`      | 2.2.27      | 1.8.8     | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us:           |
| `debian:10`      | 2.2.12      | 1.8.4     | :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us: | :bug: :es: :jp: :us:           |

Legend:
- :us: Works in Engilsh
- :es: Works in Spanish
- :jp: Works in Japanese
- :bug: Only works with `--debug=ipc`
- :warning: Substantially different stderr output


The "Substantially different" stderr output on the three :warning: cells differs from the original output by including the GPG key ID that was used to encrypt the file when "No Secret" occurs. This seems like useful information to me, so I've left it in.

Earlier versions of this table that I posted in the ticket as I went along had more entries for `centos:7`, but I deliberately removed those. There does not appear to be any way at all to get gnupg 2.0.22 to meaningfully distinguish among "Cancel", "Bad Pin" and "No Pinentry" conditions, and adding a check for one creates false-positives for others. Since passff/passff#544 is about optionally not showing the error modal, I decided the best option here would be to not have any false positives anywhere.


